### PR TITLE
Repoint archived sites to github hosted version

### DIFF
--- a/archived_sites.md
+++ b/archived_sites.md
@@ -4,11 +4,12 @@ title: Archived Sites
 ## Old Archived Jython Websites
 This is the place to access old versions of the Jython website.
 
-### [Jython 2.5 - 2.7](http://www.jython.org/)
+These versions are only for historical reference and may contain outdated or incorrect information.
 
-### [Jython 2.2.1](http://www.jython.org/archive/221/index.html)
+### [Jython 2.5 - 2.7](https://jython.github.io/jython-old-sites/)
 
-### [Jython 2.2](http://www.jython.org/archive/22/index.html)
+### [Jython 2.2.1](https://jython.github.io/jython-old-sites/archive/221/index.html)
 
-### [Jython 2.1](http://www.jython.org/archive/21/index.html)
+### [Jython 2.2](https://jython.github.io/jython-old-sites/archive/22/index.html)
 
+### [Jython 2.1](https://jython.github.io/jython-old-sites/archive/21/index.html)


### PR DESCRIPTION
This is to temporarily point the archived sites to the versions hosted at
https://jamesmudd.github.io/jython-old-sites/
This repository should be transfered to Jython organisation ans then these
links re-pointed again to the final destination.