### PR TITLE
Add Jython 2.7.2b2 links

### DIFF
--- a/download.md
+++ b/download.md
@@ -11,6 +11,18 @@ For information on installing see [Installation](installation).
 
 This version is supported on Java 7 and 8.
 
+## Current Beta Version
+A beta version is available (Jython 2.7.2b2).
+It can be downloaded here:
+- [Jython Installer](http://search.maven.org/remotecontent?filepath=org/python/jython-installer/2.7.2b2/jython-installer-2.7.2b2.jar) - Use this to install Jython.
+- [Jython Standalone](http://search.maven.org/remotecontent?filepath=org/python/jython-standalone/2.7.2b2/jython-standalone-2.7.2b2.jar) - Use this to run Jython without installing or to embed Jython in a Java application.
+- (Considered experimental) You may cite Jython 2.7.2b2 as a
+  [dependency in your Maven or Gradle build](https://search.maven.org/artifact/org.python/jython-slim/2.7.2b2/jar).
+
+For information on installing see [Installation](installation).
+
+This version is supported on Java 8 (minimum) and 11.
+
 ## Previous Versions
 Previous versions of Jython are available from:
 - [Jython Installer](https://search.maven.org/search?q=g:org.python%20AND%20a:jython-installer&core=gav)

--- a/news.md
+++ b/news.md
@@ -3,6 +3,25 @@ title: News
 ---
 ## News
 
+### Jython 2.7.2 beta (November 2019)
+
+A beta release is now available for Jython 2.7.2 at [Maven Central](https://search.maven.org/search?q=g:org.python).
+It is tested against Java 8 and Java 11.
+This has been a long time in the making, as there were quite a few bugs known that we deemed it necessary to fix.
+
+Notable new features include:
+ - A "slim" JAR that may be cited in Gradle and Maven builds, so you can take control of dependencies.
+ - Elimination (normally) the Java 9+
+   [reflective access warning](https://docs.oracle.com/javase/9/migrate/#GUID-7BB28E4D-99B3-4078-BDC4-FC24180CE82B).
+ - Much improved support for `locale`, when you opt in via property `python.locale.control=settable`.
+ - Console messages are now produced via `java.util.logging` and the `org.python` name space for you to manage.
+ - Jython command options are now closer to the CPython equivalent.
+ 
+Numerous instances are corrected where we mis-handled the encoding of file, user and host names,
+and a threading bug in type handling.
+Many more fixed bugs are listed in [NEWS](https://github.com/jythontools/jython/blob/v2.7.2b2/NEWS).
+
+
 ### New website (October 2018)
 Welcome to the new Jython website. The main improvements are:
 - Redesign to fit the modern web, e.g. mobile responsive

--- a/news.md
+++ b/news.md
@@ -11,14 +11,14 @@ This has been a long time in the making, as there were quite a few bugs known th
 
 Notable new features include:
  - A "slim" JAR that may be cited in Gradle and Maven builds, so you can take control of dependencies.
- - Elimination (normally) the Java 9+
+ - Elimination (nearly everywhere) of the Java 9+
    [reflective access warning](https://docs.oracle.com/javase/9/migrate/#GUID-7BB28E4D-99B3-4078-BDC4-FC24180CE82B).
- - Much improved support for `locale`, when you opt in via property `python.locale.control=settable`.
+ - Much improved support for `locale`, when you opt in via the property `python.locale.control=settable`.
  - Console messages are now produced via `java.util.logging` and the `org.python` name space for you to manage.
  - Jython command options are now closer to the CPython equivalent.
  
 Numerous instances are corrected where we mis-handled the encoding of file, user and host names,
-and a threading bug in type handling.
+which has been a frequent problem for users where ASCII won't do.
 Many more fixed bugs are listed in [NEWS](https://github.com/jythontools/jython/blob/v2.7.2b2/NEWS).
 
 
@@ -78,7 +78,7 @@ To see all of the files available including checksums, go here and navigate to t
 
 From announcement on [Frank Wierzbickis Weblog](http://fwierzbicki.blogspot.fi/2015/04/jython-27-release-candidate-3-available.html)
 
-### Jython 2.7 PyCon 2015 Talk** (April 2015)
+### Jython 2.7 PyCon 2015 Talk (April 2015)
 
 Jim Baker gave a talk at PyCon 2015 in Montreal about how we got to Jython 2.7 and what's coming next. [Watch the video here](https://www.youtube.com/watch?v=hLm3garVQFo&gt)
 


### PR DESCRIPTION
Updates linking the beta of 2.7.2. I've done this by editing on GitHub directly, as I was too lazy to install the Ruby, Bundler, Jekyll stack for a simple addition. Have I missed anything?

I like the way the 2.7.2b2 Javadoc has just magically appeared without me doing anything.