### PR TITLE
Announce Jython 2.7.2b3

### DIFF
--- a/download.md
+++ b/download.md
@@ -12,12 +12,12 @@ For information on installing see [Installation](installation).
 This version is supported on Java 7 and 8.
 
 ## Current Beta Version
-A beta version is available (Jython 2.7.2b2).
+A beta version is available (Jython 2.7.2b3).
 It can be downloaded here:
-- [Jython Installer](http://search.maven.org/remotecontent?filepath=org/python/jython-installer/2.7.2b2/jython-installer-2.7.2b2.jar) - Use this to install Jython.
-- [Jython Standalone](http://search.maven.org/remotecontent?filepath=org/python/jython-standalone/2.7.2b2/jython-standalone-2.7.2b2.jar) - Use this to run Jython without installing or to embed Jython in a Java application.
-- (Considered experimental) You may cite Jython 2.7.2b2 as a
-  [dependency in your Maven or Gradle build](https://search.maven.org/artifact/org.python/jython-slim/2.7.2b2/jar).
+- [Jython Installer](https://mvnrepository.com/artifact/org.python/jython-installer/2.7.2b3) - Use this to install Jython.
+- [Jython Standalone](https://mvnrepository.com/artifact/org.python/jython-standalone/2.7.2b3) - Use this to run Jython without installing or to embed Jython in a Java application.
+- (Considered experimental) You may cite Jython 2.7.2b3 as a
+  [dependency in your Maven or Gradle build](https://mvnrepository.com/artifact/org.python/jython-slim/2.7.2b3).
 
 For information on installing see [Installation](installation).
 

--- a/news.md
+++ b/news.md
@@ -9,7 +9,8 @@ A further beta release is now available for Jython 2.7.2 at
 [Maven Central](https://search.maven.org/search?q=g:org.python).
 It is built and tested with Java 8 and tested against Java 11.
 This fixes bugs raised in response to v2.7.2b2 and updates certain JARs.
-Although past predictions of releases very reliable, we predict a release candidate 24 February.
+Although past predictions of releases have not been very reliable,
+we predict a release candidate in the week beginning 24 February.
 
 Notable new features are as already listed for v2.7.2b2.
 

--- a/news.md
+++ b/news.md
@@ -3,7 +3,20 @@ title: News
 ---
 ## News
 
-### Jython 2.7.2 beta (November 2019)
+### Jython 2.7.2 beta (v2.7.2b3 February 2020)
+
+A further beta release is now available for Jython 2.7.2 at
+[Maven Central](https://search.maven.org/search?q=g:org.python).
+It is built and tested with Java 8 and tested against Java 11.
+This fixes bugs raised in response to v2.7.2b2 and updates certain JARs.
+Although past predictions of releases very reliable, we predict a release candidate 24 February.
+
+Notable new features are as already listed for v2.7.2b2.
+
+Fixed bugs are listed in [NEWS](https://github.com/jythontools/jython/blob/v2.7.2b3/NEWS).
+
+
+### Jython 2.7.2 beta (v2.7.2b2 November 2019)
 
 A beta release is now available for Jython 2.7.2 at [Maven Central](https://search.maven.org/search?q=g:org.python).
 It is tested against Java 8 and Java 11.


### PR DESCRIPTION
Announcement in news.md, and update current versions linked from downloads
page to b3.