### PR TITLE
PGP signing details and bump linked javadoc version

### DIFF
--- a/_data/navbar.yml
+++ b/_data/navbar.yml
@@ -12,7 +12,7 @@ navbar:
       - title: Installation
         url: installation
       - title: JavaDoc
-        url: https://www.javadoc.io/doc/org.python/jython-standalone/2.7.1
+        url: https://www.javadoc.io/doc/org.python/jython-standalone/2.7.2
       - title: Python 2.7
         url: https://docs.python.org/2.7/
       - title: Jython Book

--- a/download.md
+++ b/download.md
@@ -19,3 +19,25 @@ This version is supported on Java 8 (minimum) and 11.
 Previous versions of Jython are available from:
 - [Jython Installer](https://search.maven.org/artifact/org.python/jython-installer)
 - [Jython Standalone](https://search.maven.org/artifact/org.python/jython-standalone)
+
+## OpenPGP Public Keys
+
+Release files for supported releases are signed by the following:
+- Jeff Allen (2.7.2 onwards) (key id: 875C3EF9DC4638E3)
+- Frank Wierzbicki (2.7.1 and earlier) (key id: 3979A71621665974) 
+
+You can validate these keys, using the installer as an example:
+
+
+```bash
+gpg --keyserver hkp://pool.sks-keyservers.net --recv-keys [key id]
+
+gpg --verify jython-installer-[x.y.z].jar.asc \
+    jython-installer-[x.y.z].jar
+```
+
+GPG will report `Good signature from [release owner]`.
+
+GPG may also report a warning unless you explicitly tell it to trust the key. This is not necessary for one-off verification. The warning is [explained here](https://security.stackexchange.com/questions/147447/gpg-why-is-my-trusted-key-not-certified-with-a-trusted-signature). The signing keys are listed above to allow validation independent of the file repository.
+
+


### PR DESCRIPTION
As discussed recently on the mailing list. Modeled on the section at the end of the Python page https://www.python.org/downloads/