### PR TITLE
Announce v2.7.3rc1

### DIFF
--- a/download.md
+++ b/download.md
@@ -17,15 +17,16 @@ For information on installing see [Installation](installation).
 This version is supported on Java 8 (minimum) and 11.
 
 
-## Current Beta Version
-A beta version is available (Jython 2.7.3b1).
+## Current Release Candidate
+A release candidate version is available (Jython 2.7.3rc1).
+(A "release candidate" is the final safeguard before release of the official version.)
 It can be downloaded here:
-- [Jython Installer](https://repo1.maven.org/maven2/org/python/jython-installer/2.7.3b1/jython-installer-2.7.3b1.jar) - Use this to install Jython.
-  ([metadata](https://search.maven.org/artifact/org.python/jython-installer/2.7.3b1/jar))
-- [Jython Standalone](https://repo1.maven.org/maven2/org/python/jython-standalone/2.7.3b1/jython-standalone-2.7.3b1.jar) - Use this to run Jython without installing or to embed Jython in a Java application.
-  ([metadata](https://search.maven.org/artifact/org.python/jython-standalone/2.7.3b1/jar))
-- You may cite Jython 2.7.3b1 as a
-  [dependency in your Maven or Gradle build](https://search.maven.org/artifact/org.python/jython-slim/2.7.3b1/jar).
+- [Jython Installer](https://repo1.maven.org/maven2/org/python/jython-installer/2.7.3rc1/jython-installer-2.7.3rc1.jar) - Use this to install Jython.
+  ([metadata](https://search.maven.org/artifact/org.python/jython-installer/2.7.3rc1/jar))
+- [Jython Standalone](https://repo1.maven.org/maven2/org/python/jython-standalone/2.7.3rc1/jython-standalone-2.7.3rc1.jar) - Use this to run Jython without installing or to embed Jython in a Java application.
+  ([metadata](https://search.maven.org/artifact/org.python/jython-standalone/2.7.3rc1/jar))
+- You may cite Jython 2.7.3rc1 as a
+  [dependency in your Maven or Gradle build](https://search.maven.org/artifact/org.python/jython-slim/2.7.3rc1/jar).
 
 
 ## Previous Versions
@@ -51,6 +52,9 @@ gpg --verify jython-installer-[x.y.z].jar.asc \
 
 GPG will report `Good signature from [release owner]`.
 
-GPG may also report a warning unless you explicitly tell it to trust the key. This is not necessary for one-off verification. The warning is [explained here](https://security.stackexchange.com/questions/147447/gpg-why-is-my-trusted-key-not-certified-with-a-trusted-signature). The signing keys are listed above to allow validation independent of the file repository.
+GPG may also report a warning unless you explicitly tell it to trust the key.
+This is not necessary for one-off verification.
+The warning is
+[explained here](https://security.stackexchange.com/questions/147447/gpg-why-is-my-trusted-key-not-certified-with-a-trusted-signature). The signing keys are listed above to allow validation independent of the file repository.
 
 

--- a/news.md
+++ b/news.md
@@ -4,6 +4,20 @@ title: News
 
 ## News
 
+### Jython 2.7.3 release candidate (v2.7.3rc1 August 2022)
+
+A release candidate for Jython 2.7.3 is now available at
+[Maven Central](https://search.maven.org/search?q=g:org.python).
+
+There is only one change from the beta
+(a natural extension to the sequence-matching feature):
+
+- Support Java vararg constructors.
+
+The cumulative feature and bug-fix history is at
+[NEWS](https://github.com/jython/jython/blob/v2.7.3rc1/NEWS).
+
+
 ### Jython 2.7.3 beta (v2.7.3b1 July 2022)
 
 A beta release is now available for Jython 2.7.3 at [Maven Central](https://search.maven.org/search?q=g:org.python).


### PR DESCRIPTION
We announce the availability of Jython 2.7.3rc1 in the news and downloads sections.

When I last looked, it hadn't been indexed yet at Sonatype, making the links possibly confusing.