### PR TITLE
Announce v2.7.4b2

### DIFF
--- a/download.md
+++ b/download.md
@@ -20,16 +20,16 @@ This version is supported on Java 8 (minimum) and 11.
 
 
 ## Current Beta Version
-A beta version is available (Jython 2.7.4b1).
+A beta version is available (Jython 2.7.4b2).
 It can be downloaded here:
-- [Jython Installer](https://repo1.maven.org/maven2/org/python/jython-installer/2.7.4b1/jython-installer-2.7.4b1.jar) - Use this to install Jython.
-  ([metadata](https://search.maven.org/artifact/org.python/jython-installer/2.7.4b1/jar))
-- [Jython Standalone](https://repo1.maven.org/maven2/org/python/jython-standalone/2.7.4b1/jython-standalone-2.7.4b1.jar) - Use this to run Jython without installing or to embed Jython in a Java application.
-  ([metadata](https://search.maven.org/artifact/org.python/jython-standalone/2.7.4b1/jar))
-- You may cite Jython 2.7.4b1 as a
-  [dependency in your Maven or Gradle build](https://search.maven.org/artifact/org.python/jython-slim/2.7.4b1/jar).
+- [Jython Installer](https://repo1.maven.org/maven2/org/python/jython-installer/2.7.4b2/jython-installer-2.7.4b2.jar) - Use this to install Jython.
+  ([metadata](https://search.maven.org/artifact/org.python/jython-installer/2.7.4b2/jar))
+- [Jython Standalone](https://repo1.maven.org/maven2/org/python/jython-standalone/2.7.4b2/jython-standalone-2.7.4b2.jar) - Use this to run Jython without installing or to embed Jython in a Java application.
+  ([metadata](https://search.maven.org/artifact/org.python/jython-standalone/2.7.4b2/jar))
+- You may cite Jython 2.7.4b2 as a
+  [dependency in your Maven or Gradle build](https://search.maven.org/artifact/org.python/jython-slim/2.7.4b2/jar).
 
-A build from the repository will identify as Jython 2.7.4b2-something.
+A build from the repository will identify as Jython 2.7.4b3-something.
 
 
 ## Previous Versions

--- a/installation.md
+++ b/installation.md
@@ -2,15 +2,15 @@
 title: Installation
 ---
 ## Installer Jar
-Jython 2.7.2 is distributed via an executable jar file installer.  After
-[downloading](download) it, either double click the `jython-installer-2.7.2.jar` or run java with the -jar option
+Jython 2.7.3 is distributed via an executable jar file installer.  After
+[downloading](download) it, either double click the `jython-installer-2.7.3.jar` or run java with the -jar option
 ```
-$ java -jar jython-installer-2.7.2.jar
+$ java -jar jython-installer-2.7.3.jar
 ```
 
 This will start the regular GUI installer on most systems, or a console installer on headless systems.  To force the installer to work in headless mode invoke the installer as:
 ```
-$ java -jar jython-installer-2.7.2.jar --console
+$ java -jar jython-installer-2.7.3.jar --console
 ```
 The installer will then walk through a similar set of steps in
 graphical or console mode: showing the license, selecting an install
@@ -26,7 +26,7 @@ The standalone option does no caching and so avoids the startup overhead (most l
 
 You can try it out by running the installer:
 ```
-$ java -jar jython-installer-2.7.2.jar
+$ java -jar jython-installer-2.7.3.jar
 ```
 then when you come to the "Installation type" page, select "Standalone".
 
@@ -44,5 +44,5 @@ Or, add this file to the classpath of your application.
 
 You can get a list of installer options (to install Jython unattended, for example) by running:
 ```
-$ java -jar jython-installer-2.7.2.jar --help
+$ java -jar jython-installer-2.7.3.jar --help
 ```

--- a/news.md
+++ b/news.md
@@ -4,17 +4,32 @@ title: News
 
 ## News
 
+### Jython 2.7.4 beta (v2.7.4b2 May 2024)
+
+A second beta release is now available for Jython 2.7.4
+at [Maven Central](https://search.maven.org/search?q=g:org.python).
+It is tested against Java 8 and Java 11.
+
+Beta 2 adds one interesting feature:
+the JARs provide Java (automatic) modules,
+the better to support use in modular builds.
+See [NEWS](https://github.com/jython/jython/blob/v2.7.4b2/NEWS)
+for guidance on additional options that may be needed to the `java` command
+in modular usage.
+
+This addition should not interfere with traditional use on the class path,
+and does not alter Jython launch scripts.
+
 ### Jython 2.7.4 beta (v2.7.4b1 April 2024)
 
 A beta release is now available for Jython 2.7.4 at [Maven Central](https://search.maven.org/search?q=g:org.python).
 It is tested against Java 8 and Java 11.
 Thanks to all those who have helped identify and fix bugs.
 
-
 ### Jython 2.7.3 release (v2.7.3 September 2022)
 
 A new full release is now available for Jython 2.7.3 at
-[Maven Central](https://search.maven.org/search?q=g:org.python).
+[Maven Central](https://search.maven.org/search?q=g:org.python+v:2.7.3).
 It is built and tested with Java 8 and tested against Java 11.
 
 The cumulative feature and bug-fix history is at


### PR DESCRIPTION
We announce the availability of Jython 2.7.4b2 in the news and downloads sections.