### PR TITLE
Upgrade GitHub Checkout Action from v3 to v4

### DIFF
--- a/.github/workflows/codespell.yml
+++ b/.github/workflows/codespell.yml
@@ -4,6 +4,6 @@ jobs:
   codespell:
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v3
+      - uses: actions/checkout@v4
       - run: pip install codespell
       - run: codespell --count  # --ignore-words-list="" --skip="*.css,*.js,*.lock,*.po"


### PR DESCRIPTION
This PR updates the GitHub Checkout Action from version 3 to version 4 in our workflow. The upgrade is necessary as the Node.js version used in v3 will soon be out of support. By moving to v4, we ensure our workflows continue to run on a supported version of Node.js, thereby maintaining the reliability and stability of our CI/CD processes. Please review and provide your feedback.