### PR TITLE
feat: add pyforge to usage list

### DIFF
--- a/index.md
+++ b/index.md
@@ -56,4 +56,5 @@ Jython is embedded in lots of projects. See some from [MVNRepository](https://mv
 - [Robot Framework](http://robotframework.org/) - A generic test automation framework for acceptance testing and acceptance test-driven development (ATDD) which runs on Jython.
 - [TigerJython](https://www.tigerjython.ch/en) - An educational programming environment that is based on Jython.
 - [JEM/JythonMusic](https://jythonmusic.me/) - An environment for music making and creative programming using Jython.
+- [Pyforge](https://github.com/Rickaym/pyforge) - A Python language adapter for Minecraft Forge that lets you build Minecraft mods with Python.
 


### PR DESCRIPTION
Hey,

I'm a Python enthusiast. I found out about Jython a few years back; it surfaced to me as this cool bridge between Python and Java. This led me to create pyforge, which lets you write Minecraft Forge mods in Jython. I think it is very interesting to see where this goes once Jython 3 becomes a reality and the ecosystem develops for a better developer experience.

I'm unsure if extending this list on the Jython page is allowed, so this is more like an inquiry on if pyforge could be featured!

Thanks,
Ricky.
